### PR TITLE
Update logger initialization, allow usage on non-CAS systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,14 @@ keywords = ["logging", "cortex-m", "risc-v", "rtt"]
 log = "0.4.0"
 rtt-target = { version = "0.5.0" }
 
+[dependencies.once_cell]
+version = "1"
+default-features = false
+features = ["critical-section"]
+
 [features]
 default = []
+racy_init = []
 
 [lib]
 doctest = false


### PR DESCRIPTION
1. Initialization uses a OnceCell<Logger> instead of a static mut now. Clippy will warn about the usage of mutable statics (static_mut_refs lint) which will become a hard error in Rust edition 2024.
2. Library can now be used on smaller systems which do not have CAS operations by default. On these systems, the racy log API will be used. The usage of OnceCell should ensure that there are no races.